### PR TITLE
Edit example to show custom port usage, add better logging for HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ def predict(data):
     """
     return body
 
-app.start()
+app.start(port=4000) # port is 4000 by default
 ```
 
 By default, the server starts at port `4000`. The `predict` function will run with GET/POST requests on `/predict`.
@@ -48,7 +48,7 @@ Some of the features we're still working on:
 
 - [x] Pass POST request String and JSON into the Python function.
 - [x] Return String and JSON with the correct content type headers.
-- [ ] Graceful error handling (⚠️ Priority).
+- [x] Graceful error handling (⚠️ Priority).
 - [ ] Customise the route and port for the main task.
 - [ ] Allow more datatypes for POST request to the model.
 - [ ] Create more examples.

--- a/examples/json_requests/main.py
+++ b/examples/json_requests/main.py
@@ -9,5 +9,5 @@ def main(data):
   print(data["key"])
   return data
 
-app.start()
 
+app.start(port=5001)


### PR DESCRIPTION
meteorite restricted the port for the API to be 4000. That issue has been solved by having an `Option` port parameter for the definition of the `start` function.